### PR TITLE
[TASK] Change slack channel recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Find the full [Documentation](https://github.com/TYPO3-Initiatives/content-block
 ### Status
 
 `alpha` - the main concepts are laid out but nothing is polished yet. We welcome your feedback.
-You can reach us in the TYPO3 Slack `#cig-structuredcontent-contentblockcreation` ❤️.
+You can reach us in the TYPO3 Slack `#cig-structuredcontent` ❤️.
 
 ## Installation
 


### PR DESCRIPTION
The old slack channel #cig-structuredcontent-contentblockcreation
is archived and discussion is moved to #cig-structuredcontent.

Fixes: #84