### PR TITLE
Fix for typos in examples

### DIFF
--- a/Documentation/IntegratorManual/YamlReference/Url/Index.rst
+++ b/Documentation/IntegratorManual/YamlReference/Url/Index.rst
@@ -65,7 +65,7 @@ linkPopup
       linkPopup:
         allowedExtensions: 'pdf'
         blindLinkFields: 'target,title'
-        blindLinkOptions: 'folder,spec,telefone,mail'
+        blindLinkOptions: 'folder,spec,telephone,mail'
         windowOpenParameters: 'height=800,width=600'
 
 max
@@ -147,7 +147,7 @@ Example
           linkPopup:
             allowedExtensions: 'pdf'
             blindLinkFields: 'target,title'
-            blindLinkOptions: 'folder,spec,telefone,mail'
+            blindLinkOptions: 'folder,spec,telephone,mail'
           max: 150
           placeholder: 'Placeholder text'
           required: false


### PR DESCRIPTION
blindLinkOptions for telephone need to be written with 'ph' to work as intended. Spelling in the text is correct, but the examples were written with 'telefone'